### PR TITLE
Expand CMS-editable content: footer, contact, about, and home subsect…

### DIFF
--- a/_data/about.yml
+++ b/_data/about.yml
@@ -1,0 +1,22 @@
+story:
+  heading: Our Story
+  paragraphs:
+    - DineStar was founded on the belief that luxury and sustainability are not mutually exclusive. Our journey began in the lush palm groves of South Asia, where we discovered the incredible potential of the naturally fallen Areca palm leaf.
+    - Today, we are a global leader in sustainable dinnerware, committed to ethical sourcing, zero-waste manufacturing, and providing our customers with products that are as beautiful as they are kind to the planet.
+  image: https://picsum.photos/seed/about1/800/600
+  image_alt: Our Team
+  stat_number: "10+"
+  stat_label: Years of Innovation
+
+values:
+  heading: Our Core Values
+  items:
+    - icon: eco
+      title: Sustainability
+      description: Every decision we make is guided by its impact on the environment.
+    - icon: diamond
+      title: Quality
+      description: We never compromise on the premium feel and durability of our products.
+    - icon: groups
+      title: Community
+      description: We support the local communities that harvest and craft our materials.

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -1,0 +1,22 @@
+heading: Get in Touch
+subheading: Have questions about our products or services? We're here to help you transition to a more sustainable table.
+
+info:
+  - icon: location_on
+    color: primary
+    label: Our Headquarters
+    value: 123 Palm Grove Ave, Eco City, EC 45678
+  - icon: call
+    color: secondary
+    label: Phone Number
+    value: +1 (555) 123-4567
+  - icon: mail
+    color: tertiary
+    label: Email Address
+    value: hello@dinestar.com
+
+hours_heading: Business Hours
+hours:
+  - { day: Monday - Friday, time: 9:00 AM - 6:00 PM }
+  - { day: Saturday,        time: 10:00 AM - 4:00 PM }
+  - { day: Sunday,          time: Closed }

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,0 +1,26 @@
+tagline: Redefining dinnerware through the wisdom of nature. Premium palm leaf containers for a sustainable future.
+
+social:
+  - { icon: public, url: "#", label: Website }
+  - { icon: mail,   url: "#", label: Email }
+
+columns:
+  - heading: Company
+    links:
+      - { label: About Us, url: /about.html }
+      - { label: Sustainability Report, url: "#" }
+      - { label: Our Process, url: "#" }
+      - { label: Terms of Service, url: "#" }
+  - heading: Solutions
+    links:
+      - { label: Wholesale Inquiries, url: "#" }
+      - { label: Event Services, url: /services.html }
+      - { label: Brochure, url: /brochure.html }
+      - { label: Privacy Policy, url: /contact.html }
+
+copyright_owner: DineStar Sustainable Solutions
+copyright_suffix: Crafted with 100% natural palm leaves.
+
+badges:
+  - ISO 9001 CERTIFIED
+  - FDA APPROVED

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -7,3 +7,46 @@ hero:
   secondary_button: Our Story
   image: https://lh3.googleusercontent.com/aida-public/AB6AXuD69Gb7P0TzxuD7TSPcYkigNZC8qKPITHmfFobZvUEXKdsj0K4-pTKZY0N2U58amAiFVg_axQZX9cDriyBkFx5cw517Po9zhwt3TQy8-cPrB4gtnAoMnWWfISe5bEh1UdyroqXn0Exkr4BMp-nf67W6xktsAm1Sb13I4P1yj3jIELIV13ymHX6ylBngK7TcMeT38NsEALwQh3pGfjYg-ERuoDtd5Ko9BAdc014W9UhTFE38tQVpbNcpSKnVV7gm5FAD9mVAor6qRg58
   image_alt: Palm Leaf Dinnerware
+
+curated_essentials:
+  eyebrow: The Collection
+  heading: Curated Essentials
+  view_all_label: View All Products
+  view_all_url: /products.html
+  featured:
+    badge: Bestseller
+    title: Dinnerware Sets
+    description: Perfect for eco-conscious hosting and premium events.
+    image: https://lh3.googleusercontent.com/aida-public/AB6AXuBXRm5EWDyFJhycRxa05qHk_2Uj4eKuQF6zAYY3WchOYHlz-X-akt09RbCshc3PNQyT7DTENuwprGLo6nI-aLQ7sSZf9AWNzBJyvs8Cz5C9myBzI28n3xxTTQVZYOcoU05aDn0XKadA9oSFiVBO0LlZqSrhEuIp5zOCYpqKonE6XJHA2sVHtuX5ChYbwkpiyyOig765WNBKj8yYI-r8O-qfIcvukOp8hGvS1OVhrFiZzv0CHK0a3F-wjT5qdXsumHBDAp0R754aSrVX
+  secondary:
+    title: Artisan Bowls
+    image: https://lh3.googleusercontent.com/aida-public/AB6AXuDMn7AyQeNXL-yurJ9sZvU3UqEGOqXJfP0xuZ_xvp7t85O9y4h3arfAVRKOQWyRFQ2FrJvOuFAA0Mj7jF2sBEkG8gjaeZR_A5evgBwELL-SrL709SZImxVMlAdf5lQCQyC9YyobDWQcTvoPMflPhLBgMZiTmfgctlt3wZpqSrrAPRj2aO82ahOdRmJwn2R2OWUtnjITkeF_XgYPVeUWyuO3fb_ZezvjVF4CCPR6pF9ZDUd0OT2y_ruCJ8PoD7vcqQ5xc4_imEvGkyet
+  small:
+    title: Natural Utensils
+    image: https://lh3.googleusercontent.com/aida-public/AB6AXuCIuiGaDabI9QcwjTySRoxIgPZRJgLJO3vrwsxSow8D5odrdUH2nVxXSPPVS5_Jvc-D8_QZ2fSdJ1esT1ITrUnym4UsDMctQwdndABKFpLW5fnwqkxOz29uMtf1r_wWu2ogRcdQ0EuwEAn4Z3tPbv-eW413Xc9meisaxve_LWJcravOkC4B3Z2fUC94_aI9ZLDRLytLwD4vWt78qSEw4zmLooNOl61HXebS2LkFpI_QT71ZMBDNBw_3C-lZgUWwXM9NjhxvW8hCajeR
+  custom:
+    icon: eco
+    title: Custom Orders
+    description: Wholesale solutions for your brand.
+
+heritage:
+  eyebrow: Our Heritage
+  heading: Born from the Earth
+  paragraphs:
+    - "DineStar began with a simple observation: nature already creates the perfect container. We harvest naturally fallen leaves from the Areca palm, ensuring no trees are ever cut down."
+    - Each piece is sterilized and heat-pressed using pure steam. No chemicals, no glues, no toxins. Just the raw, textured beauty of the palm leaf, preserved for your table.
+  image: https://lh3.googleusercontent.com/aida-public/AB6AXuCd5-EPeM73gZftd4jkoyZaT3wjae4thy_tvHlE0XvZ7_xjjQ5sREcbMu102_5sDO49-jUupW7PPcJzvRZMmv0kDMqXMOVFaZci7xdpEJ371-K5QQgXYSEx_HlSmZgKLjEt9SG39MnU4Ekm32lbFp9UqHSy-UW0rn1U8Hnu3jEbCkzV6grckPap5IcaYE2zjUFxo1wkVYm2cmkKyHdKG31nzYFb-8ZNirqkipebn2vwHKnJhn2OoEgGgkSrTOrFe0rh7QhWNZ-1wLch
+  image_alt: Palm Plantation
+  badge: 100% Home Compostable
+  features:
+    - Zero Chemicals
+    - Microwavable
+    - Water Resistant
+    - Oven Safe
+    - Refrigerator safe
+
+cta:
+  heading: Ready to Elevate Your Table?
+  description: Join the sustainable luxury movement. Whether it's an intimate dinner or a grand event, DineStar provides the organic touch your guests will remember.
+  primary_button: Shop Now
+  secondary_button: Request Sample Kit

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,4 @@
+{% assign f = site.data.footer %}
 <footer class="bg-surface-container-highest w-full">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 px-6 md:px-12 py-16 max-w-7xl mx-auto">
         <div class="space-y-6">
@@ -5,45 +6,37 @@
                 <span class="text-2xl font-bold text-primary tracking-tight">DineStar</span>
             </div>
             <p class="text-secondary leading-relaxed max-w-xs">
-                Redefining dinnerware through the wisdom of nature. Premium palm leaf containers for a sustainable future.
+                {{ f.tagline }}
             </p>
             <div class="flex gap-4">
-                <a class="w-10 h-10 rounded-full bg-white flex items-center justify-center text-primary hover:scale-110 transition-transform editorial-shadow" href="#">
-                    <span class="material-symbols-outlined">public</span>
+                {% for link in f.social %}
+                <a class="w-10 h-10 rounded-full bg-white flex items-center justify-center text-primary hover:scale-110 transition-transform editorial-shadow" href="{{ link.url }}" aria-label="{{ link.label }}">
+                    <span class="material-symbols-outlined">{{ link.icon }}</span>
                 </a>
-                <a class="w-10 h-10 rounded-full bg-white flex items-center justify-center text-primary hover:scale-110 transition-transform editorial-shadow" href="#">
-                    <span class="material-symbols-outlined">mail</span>
-                </a>
+                {% endfor %}
             </div>
         </div>
         <div class="grid grid-cols-2 gap-8 md:col-span-2">
+            {% for col in f.columns %}
             <div>
-                <h4 class="font-bold text-primary mb-6 uppercase text-sm tracking-widest">Company</h4>
+                <h4 class="font-bold text-primary mb-6 uppercase text-sm tracking-widest">{{ col.heading }}</h4>
                 <ul class="space-y-4">
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="{{ '/about.html' | relative_url }}">About Us</a></li>
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="#">Sustainability Report</a></li>
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="#">Our Process</a></li>
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="#">Terms of Service</a></li>
+                    {% for link in col.links %}
+                    <li><a class="text-secondary hover:text-primary transition-colors" href="{{ link.url | relative_url }}">{{ link.label }}</a></li>
+                    {% endfor %}
                 </ul>
             </div>
-            <div>
-                <h4 class="font-bold text-primary mb-6 uppercase text-sm tracking-widest">Solutions</h4>
-                <ul class="space-y-4">
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="#">Wholesale Inquiries</a></li>
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="{{ '/services.html' | relative_url }}">Event Services</a></li>
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="{{ '/brochure.html' | relative_url }}">Brochure</a></li>
-                    <li><a class="text-secondary hover:text-primary transition-colors" href="{{ '/contact.html' | relative_url }}">Privacy Policy</a></li>
-                </ul>
-            </div>
+            {% endfor %}
         </div>
     </div>
     <div class="max-w-7xl mx-auto px-6 md:px-12 py-8 border-t border-outline-variant/20 flex flex-col md:flex-row justify-between items-center gap-4">
         <p class="text-sm text-secondary text-center md:text-left">
-            &copy; {{ 'now' | date: '%Y' }} DineStar Sustainable Solutions. Crafted with 100% natural palm leaves.
+            &copy; {{ 'now' | date: '%Y' }} {{ f.copyright_owner }}. {{ f.copyright_suffix }}
         </p>
         <div class="flex gap-6">
-            <span class="text-xs font-bold text-primary">ISO 9001 CERTIFIED</span>
-            <span class="text-xs font-bold text-primary">FDA APPROVED</span>
+            {% for badge in f.badges %}
+            <span class="text-xs font-bold text-primary">{{ badge }}</span>
+            {% endfor %}
         </div>
     </div>
 </footer>

--- a/about.html
+++ b/about.html
@@ -3,52 +3,40 @@ layout: default
 title: About Us | DineStar
 nav_active: about
 ---
+{% assign a = site.data.about %}
 <main class="pt-32 pb-24">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-16 items-center mb-24">
-                <div>
-                    <h1 class="text-5xl font-extrabold text-primary mb-6 tracking-tight">Our Story</h1>
-                    <p class="text-lg text-on-surface-variant leading-relaxed mb-6">
-                        DineStar was founded on the belief that luxury and sustainability are not mutually exclusive. Our journey began in the lush palm groves of South Asia, where we discovered the incredible potential of the naturally fallen Areca palm leaf.
-                    </p>
-                    <p class="text-lg text-on-surface-variant leading-relaxed">
-                        Today, we are a global leader in sustainable dinnerware, committed to ethical sourcing, zero-waste manufacturing, and providing our customers with products that are as beautiful as they are kind to the planet.
-                    </p>
-                </div>
-                <div class="relative">
-                    <img src="https://picsum.photos/seed/about1/800/600" alt="Our Team" class="rounded-2xl editorial-shadow w-full" referrerPolicy="no-referrer">
-                    <div class="absolute -bottom-6 -left-6 bg-primary-container text-on-primary-container p-8 rounded-2xl editorial-shadow hidden lg:block">
-                        <p class="text-3xl font-bold mb-1">10+</p>
-                        <p class="text-sm uppercase tracking-widest font-bold">Years of Innovation</p>
-                    </div>
-                </div>
+    <div class="max-w-7xl mx-auto px-6 md:px-12">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-16 items-center mb-24">
+            <div>
+                <h1 class="text-5xl font-extrabold text-primary mb-6 tracking-tight">{{ a.story.heading }}</h1>
+                {% for p in a.story.paragraphs %}
+                <p class="text-lg text-on-surface-variant leading-relaxed{% if forloop.last == false %} mb-6{% endif %}">
+                    {{ p }}
+                </p>
+                {% endfor %}
             </div>
-
-            <div class="bg-surface-container-low rounded-3xl p-12 md:p-20">
-                <h2 class="text-3xl font-bold text-primary mb-12 text-center">Our Core Values</h2>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-12">
-                    <div class="text-center">
-                        <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center text-primary mx-auto mb-6 editorial-shadow">
-                            <span class="material-symbols-outlined text-3xl">eco</span>
-                        </div>
-                        <h3 class="text-xl font-bold text-primary mb-3">Sustainability</h3>
-                        <p class="text-on-surface-variant">Every decision we make is guided by its impact on the environment.</p>
-                    </div>
-                    <div class="text-center">
-                        <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center text-primary mx-auto mb-6 editorial-shadow">
-                            <span class="material-symbols-outlined text-3xl">diamond</span>
-                        </div>
-                        <h3 class="text-xl font-bold text-primary mb-3">Quality</h3>
-                        <p class="text-on-surface-variant">We never compromise on the premium feel and durability of our products.</p>
-                    </div>
-                    <div class="text-center">
-                        <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center text-primary mx-auto mb-6 editorial-shadow">
-                            <span class="material-symbols-outlined text-3xl">groups</span>
-                        </div>
-                        <h3 class="text-xl font-bold text-primary mb-3">Community</h3>
-                        <p class="text-on-surface-variant">We support the local communities that harvest and craft our materials.</p>
-                    </div>
+            <div class="relative">
+                <img src="{{ a.story.image | relative_url }}" alt="{{ a.story.image_alt }}" class="rounded-2xl editorial-shadow w-full" referrerPolicy="no-referrer">
+                <div class="absolute -bottom-6 -left-6 bg-primary-container text-on-primary-container p-8 rounded-2xl editorial-shadow hidden lg:block">
+                    <p class="text-3xl font-bold mb-1">{{ a.story.stat_number }}</p>
+                    <p class="text-sm uppercase tracking-widest font-bold">{{ a.story.stat_label }}</p>
                 </div>
             </div>
         </div>
-    </main>
+
+        <div class="bg-surface-container-low rounded-3xl p-12 md:p-20">
+            <h2 class="text-3xl font-bold text-primary mb-12 text-center">{{ a.values.heading }}</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-12">
+                {% for v in a.values.items %}
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center text-primary mx-auto mb-6 editorial-shadow">
+                        <span class="material-symbols-outlined text-3xl">{{ v.icon }}</span>
+                    </div>
+                    <h3 class="text-xl font-bold text-primary mb-3">{{ v.title }}</h3>
+                    <p class="text-on-surface-variant">{{ v.description }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</main>

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -22,7 +22,7 @@ collections:
       - file: _data/home.yml
         name: home
         label: Home page
-        description: The hero section at the top of the home page.
+        description: All sections on the home page (hero, curated essentials, heritage, CTA).
         fields:
           - label: Hero section
             name: hero
@@ -36,6 +36,69 @@ collections:
               - { label: Secondary button label, name: secondary_button, widget: string }
               - { label: Hero image, name: image, widget: image }
               - { label: Hero image alt text, name: image_alt, widget: string }
+
+          - label: Curated Essentials section
+            name: curated_essentials
+            widget: object
+            fields:
+              - { label: Eyebrow, name: eyebrow, widget: string }
+              - { label: Heading, name: heading, widget: string }
+              - { label: "View all" link label, name: view_all_label, widget: string }
+              - { label: "View all" link URL, name: view_all_url, widget: string, hint: "e.g. /products.html or # for none" }
+              - label: Featured card (large)
+                name: featured
+                widget: object
+                fields:
+                  - { label: Badge (e.g. Bestseller), name: badge, widget: string, required: false }
+                  - { label: Title, name: title, widget: string }
+                  - { label: Description, name: description, widget: text }
+                  - { label: Image, name: image, widget: image }
+              - label: Secondary card (wide)
+                name: secondary
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string }
+                  - { label: Image, name: image, widget: image }
+              - label: Small card (with image)
+                name: small
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string }
+                  - { label: Image, name: image, widget: image }
+              - label: Custom Orders card (icon, no image)
+                name: custom
+                widget: object
+                fields:
+                  - { label: Icon (Material Symbol), name: icon, widget: string, hint: "e.g. eco, star" }
+                  - { label: Title, name: title, widget: string }
+                  - { label: Description, name: description, widget: text }
+
+          - label: Heritage section
+            name: heritage
+            widget: object
+            fields:
+              - { label: Eyebrow, name: eyebrow, widget: string }
+              - { label: Heading, name: heading, widget: string }
+              - label: Paragraphs
+                name: paragraphs
+                widget: list
+                field: { label: Paragraph, name: paragraph, widget: text }
+              - { label: Image, name: image, widget: image }
+              - { label: Image alt text, name: image_alt, widget: string }
+              - { label: Image badge text (corner overlay), name: badge, widget: string, required: false }
+              - label: Feature bullets
+                name: features
+                widget: list
+                field: { label: Feature, name: feature, widget: string }
+
+          - label: Call-to-action section
+            name: cta
+            widget: object
+            fields:
+              - { label: Heading, name: heading, widget: string }
+              - { label: Description, name: description, widget: text }
+              - { label: Primary button label, name: primary_button, widget: string }
+              - { label: Secondary button label, name: secondary_button, widget: string }
 
       - file: _data/products.yml
         name: products
@@ -74,6 +137,67 @@ collections:
                 options: [primary, secondary, tertiary, surface]
                 default: primary
 
+      - file: _data/about.yml
+        name: about
+        label: About page
+        description: "Our Story" and "Our Core Values" sections.
+        fields:
+          - label: Story section
+            name: story
+            widget: object
+            fields:
+              - { label: Heading, name: heading, widget: string }
+              - label: Paragraphs
+                name: paragraphs
+                widget: list
+                field: { label: Paragraph, name: paragraph, widget: text }
+              - { label: Image, name: image, widget: image }
+              - { label: Image alt text, name: image_alt, widget: string }
+              - { label: Stat number (e.g. "10+"), name: stat_number, widget: string }
+              - { label: Stat label, name: stat_label, widget: string }
+          - label: Values section
+            name: values
+            widget: object
+            fields:
+              - { label: Heading, name: heading, widget: string }
+              - label: Value cards
+                name: items
+                widget: list
+                summary: "{{fields.title}}"
+                fields:
+                  - { label: Icon (Material Symbol), name: icon, widget: string }
+                  - { label: Title, name: title, widget: string }
+                  - { label: Description, name: description, widget: text }
+
+      - file: _data/contact.yml
+        name: contact
+        label: Contact page
+        description: Contact info and business hours (the form itself is fixed).
+        fields:
+          - { label: Heading, name: heading, widget: string }
+          - { label: Subheading, name: subheading, widget: text }
+          - label: Contact info items
+            name: info
+            widget: list
+            summary: "{{fields.label}} — {{fields.value}}"
+            fields:
+              - { label: Icon (Material Symbol), name: icon, widget: string, hint: "e.g. location_on, call, mail" }
+              - label: Color theme
+                name: color
+                widget: select
+                options: [primary, secondary, tertiary, surface]
+                default: primary
+              - { label: Label (e.g. "Phone Number"), name: label, widget: string }
+              - { label: Value (the actual address/number/email), name: value, widget: string }
+          - { label: Business hours heading, name: hours_heading, widget: string }
+          - label: Business hours
+            name: hours
+            widget: list
+            summary: "{{fields.day}}: {{fields.time}}"
+            fields:
+              - { label: Day(s), name: day, widget: string }
+              - { label: Time, name: time, widget: string }
+
       - file: _data/brochure.yml
         name: brochure
         label: Brochure page
@@ -90,3 +214,37 @@ collections:
           - { label: Download button label, name: download_label, widget: string, hint: "e.g. Download PDF (12.4 MB)" }
           - { label: Download URL (or upload a PDF), name: download_url, widget: file, required: false, media_library: { config: { multiple: false } } }
           - { label: Preview image, name: preview_image, widget: image }
+
+      - file: _data/footer.yml
+        name: footer
+        label: Footer
+        description: Tagline, social links, and link columns shown at the bottom of every page.
+        fields:
+          - { label: Tagline, name: tagline, widget: text }
+          - label: Social icon links
+            name: social
+            widget: list
+            summary: "{{fields.label}}"
+            fields:
+              - { label: Icon (Material Symbol), name: icon, widget: string, hint: "e.g. public, mail, phone" }
+              - { label: URL, name: url, widget: string }
+              - { label: Accessible label, name: label, widget: string }
+          - label: Link columns
+            name: columns
+            widget: list
+            summary: "{{fields.heading}}"
+            fields:
+              - { label: Column heading, name: heading, widget: string }
+              - label: Links
+                name: links
+                widget: list
+                summary: "{{fields.label}}"
+                fields:
+                  - { label: Label, name: label, widget: string }
+                  - { label: URL, name: url, widget: string }
+          - { label: Copyright owner, name: copyright_owner, widget: string }
+          - { label: Copyright suffix line, name: copyright_suffix, widget: string }
+          - label: Certification badges
+            name: badges
+            widget: list
+            field: { label: Badge text, name: badge, widget: string }

--- a/contact.html
+++ b/contact.html
@@ -3,97 +3,85 @@ layout: default
 title: Contact Us | DineStar
 nav_active: contact
 ---
+{% assign c = site.data.contact %}
 <main class="pt-32 pb-24">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <header class="mb-16 text-center">
-                <h1 class="text-5xl font-extrabold text-primary mb-4 tracking-tight">Get in Touch</h1>
-                <p class="text-lg text-on-surface-variant max-w-2xl mx-auto">Have questions about our products or services? We're here to help you transition to a more sustainable table.</p>
-            </header>
+    <div class="max-w-7xl mx-auto px-6 md:px-12">
+        <header class="mb-16 text-center">
+            <h1 class="text-5xl font-extrabold text-primary mb-4 tracking-tight">{{ c.heading }}</h1>
+            <p class="text-lg text-on-surface-variant max-w-2xl mx-auto">{{ c.subheading }}</p>
+        </header>
 
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-16">
-                <!-- Contact Form -->
-                <div class="bg-surface-container-low rounded-3xl p-8 md:p-12 editorial-shadow">
-                    <form class="space-y-6">
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <div>
-                                <label class="block text-sm font-bold text-primary mb-2" for="name">Full Name</label>
-                                <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="name" placeholder="John Doe" type="text">
-                            </div>
-                            <div>
-                                <label class="block text-sm font-bold text-primary mb-2" for="email">Email Address</label>
-                                <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="email" placeholder="john@example.com" type="email">
-                            </div>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-16">
+            <!-- Contact Form -->
+            <div class="bg-surface-container-low rounded-3xl p-8 md:p-12 editorial-shadow">
+                <form class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div>
+                            <label class="block text-sm font-bold text-primary mb-2" for="name">Full Name</label>
+                            <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="name" placeholder="John Doe" type="text">
                         </div>
                         <div>
-                            <label class="block text-sm font-bold text-primary mb-2" for="subject">Subject</label>
-                            <select class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="subject">
-                                <option>General Inquiry</option>
-                                <option>Wholesale Request</option>
-                                <option>Event Catering</option>
-                                <option>Custom Branding</option>
-                            </select>
+                            <label class="block text-sm font-bold text-primary mb-2" for="email">Email Address</label>
+                            <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="email" placeholder="john@example.com" type="email">
                         </div>
-                        <div>
-                            <label class="block text-sm font-bold text-primary mb-2" for="message">Message</label>
-                            <textarea class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all h-32" id="message" placeholder="How can we help you?"></textarea>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-bold text-primary mb-2" for="subject">Subject</label>
+                        <select class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="subject">
+                            <option>General Inquiry</option>
+                            <option>Wholesale Request</option>
+                            <option>Event Catering</option>
+                            <option>Custom Branding</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-bold text-primary mb-2" for="message">Message</label>
+                        <textarea class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all h-32" id="message" placeholder="How can we help you?"></textarea>
+                    </div>
+                    <button class="w-full py-4 organic-gradient text-on-primary rounded-xl font-bold text-lg hover:scale-[1.02] transition-transform editorial-shadow" type="submit">
+                        Send Message
+                    </button>
+                </form>
+            </div>
+
+            <!-- Contact Info -->
+            <div class="flex flex-col justify-center space-y-12">
+                <div>
+                    <h3 class="text-2xl font-bold text-primary mb-6">Contact Information</h3>
+                    <div class="space-y-6">
+                        {% for item in c.info %}
+                        <div class="flex items-center gap-4">
+                            {% case item.color %}
+                              {% when 'primary' %}
+                                <div class="w-12 h-12 bg-primary-container rounded-xl flex items-center justify-center text-on-primary-container">
+                              {% when 'secondary' %}
+                                <div class="w-12 h-12 bg-secondary-container rounded-xl flex items-center justify-center text-on-secondary-container">
+                              {% when 'tertiary' %}
+                                <div class="w-12 h-12 bg-tertiary-container rounded-xl flex items-center justify-center text-on-tertiary-container">
+                              {% else %}
+                                <div class="w-12 h-12 bg-surface-container-highest rounded-xl flex items-center justify-center text-primary">
+                            {% endcase %}
+                                <span class="material-symbols-outlined">{{ item.icon }}</span>
+                            </div>
+                            <div>
+                                <p class="font-bold text-primary">{{ item.label }}</p>
+                                <p class="text-on-surface-variant">{{ item.value }}</p>
+                            </div>
                         </div>
-                        <button class="w-full py-4 organic-gradient text-on-primary rounded-xl font-bold text-lg hover:scale-[1.02] transition-transform editorial-shadow" type="submit">
-                            Send Message
-                        </button>
-                    </form>
+                        {% endfor %}
+                    </div>
                 </div>
 
-                <!-- Contact Info -->
-                <div class="flex flex-col justify-center space-y-12">
-                    <div>
-                        <h3 class="text-2xl font-bold text-primary mb-6">Contact Information</h3>
-                        <div class="space-y-6">
-                            <div class="flex items-center gap-4">
-                                <div class="w-12 h-12 bg-primary-container rounded-xl flex items-center justify-center text-on-primary-container">
-                                    <span class="material-symbols-outlined">location_on</span>
-                                </div>
-                                <div>
-                                    <p class="font-bold text-primary">Our Headquarters</p>
-                                    <p class="text-on-surface-variant">123 Palm Grove Ave, Eco City, EC 45678</p>
-                                </div>
-                            </div>
-                            <div class="flex items-center gap-4">
-                                <div class="w-12 h-12 bg-secondary-container rounded-xl flex items-center justify-center text-on-secondary-container">
-                                    <span class="material-symbols-outlined">call</span>
-                                </div>
-                                <div>
-                                    <p class="font-bold text-primary">Phone Number</p>
-                                    <p class="text-on-surface-variant">+1 (555) 123-4567</p>
-                                </div>
-                            </div>
-                            <div class="flex items-center gap-4">
-                                <div class="w-12 h-12 bg-tertiary-container rounded-xl flex items-center justify-center text-on-tertiary-container">
-                                    <span class="material-symbols-outlined">mail</span>
-                                </div>
-                                <div>
-                                    <p class="font-bold text-primary">Email Address</p>
-                                    <p class="text-on-surface-variant">hello@dinestar.com</p>
-                                </div>
-                            </div>
-                        </div>
+                <div class="bg-surface-container-high rounded-3xl p-8">
+                    <h4 class="font-bold text-primary mb-4">{{ c.hours_heading }}</h4>
+                    {% for row in c.hours %}
+                    <div class="flex justify-between text-on-surface-variant{% if forloop.first == false %} mt-2{% endif %}">
+                        <span>{{ row.day }}</span>
+                        <span>{{ row.time }}</span>
                     </div>
-
-                    <div class="bg-surface-container-high rounded-3xl p-8">
-                        <h4 class="font-bold text-primary mb-4">Business Hours</h4>
-                        <div class="flex justify-between text-on-surface-variant">
-                            <span>Monday - Friday</span>
-                            <span>9:00 AM - 6:00 PM</span>
-                        </div>
-                        <div class="flex justify-between text-on-surface-variant mt-2">
-                            <span>Saturday</span>
-                            <span>10:00 AM - 4:00 PM</span>
-                        </div>
-                        <div class="flex justify-between text-on-surface-variant mt-2">
-                            <span>Sunday</span>
-                            <span>Closed</span>
-                        </div>
-                    </div>
+                    {% endfor %}
                 </div>
             </div>
         </div>
-    </main>
+    </div>
+</main>

--- a/index.html
+++ b/index.html
@@ -4,144 +4,139 @@ title: DineStar | Sustainable Palm Leaf Dinnerware
 nav_active: home
 ---
 {% assign hero = site.data.home.hero %}
+{% assign curated = site.data.home.curated_essentials %}
+{% assign heritage = site.data.home.heritage %}
+{% assign cta = site.data.home.cta %}
+
 <!-- Hero Section -->
-    <header class="relative min-h-screen flex items-center pt-20 overflow-hidden bg-surface">
-        <div class="max-w-7xl mx-auto px-6 md:px-12 w-full grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
-            <div class="z-10">
-                <span class="text-tertiary font-semibold tracking-widest text-sm uppercase mb-4 block">{{ hero.eyebrow }}</span>
-                <h1 class="text-6xl md:text-7xl font-extrabold text-primary leading-tight tracking-tighter mb-6">
-                    {{ hero.heading_line_1 }} <br> {{ hero.heading_line_2 }}
-                </h1>
-                <p class="text-lg text-on-surface-variant leading-relaxed mb-10 max-w-lg">
-                    {{ hero.description }}
-                </p>
-                <div class="flex flex-wrap gap-4">
-                    <button class="px-8 py-4 organic-gradient text-on-primary rounded-3xl font-bold text-lg hover:scale-105 transition-transform editorial-shadow">
-                        {{ hero.primary_button }}
-                    </button>
-                    <button class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
-                        {{ hero.secondary_button }}
-                    </button>
-                </div>
-            </div>
-            <div class="relative group">
-                <div class="absolute -inset-4 bg-tertiary-container/10 rounded-full blur-3xl group-hover:bg-tertiary-container/20 transition-colors"></div>
-                <img alt="{{ hero.image_alt }}" class="relative rounded-2xl editorial-shadow w-full aspect-square object-cover transform rotate-2 hover:rotate-0 transition-transform duration-500" src="{{ hero.image | relative_url }}" referrerPolicy="no-referrer">
+<header class="relative min-h-screen flex items-center pt-20 overflow-hidden bg-surface">
+    <div class="max-w-7xl mx-auto px-6 md:px-12 w-full grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+        <div class="z-10">
+            <span class="text-tertiary font-semibold tracking-widest text-sm uppercase mb-4 block">{{ hero.eyebrow }}</span>
+            <h1 class="text-6xl md:text-7xl font-extrabold text-primary leading-tight tracking-tighter mb-6">
+                {{ hero.heading_line_1 }} <br> {{ hero.heading_line_2 }}
+            </h1>
+            <p class="text-lg text-on-surface-variant leading-relaxed mb-10 max-w-lg">
+                {{ hero.description }}
+            </p>
+            <div class="flex flex-wrap gap-4">
+                <button class="px-8 py-4 organic-gradient text-on-primary rounded-3xl font-bold text-lg hover:scale-105 transition-transform editorial-shadow">
+                    {{ hero.primary_button }}
+                </button>
+                <button class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
+                    {{ hero.secondary_button }}
+                </button>
             </div>
         </div>
-    </header>
+        <div class="relative group">
+            <div class="absolute -inset-4 bg-tertiary-container/10 rounded-full blur-3xl group-hover:bg-tertiary-container/20 transition-colors"></div>
+            <img alt="{{ hero.image_alt }}" class="relative rounded-2xl editorial-shadow w-full aspect-square object-cover transform rotate-2 hover:rotate-0 transition-transform duration-500" src="{{ hero.image | relative_url }}" referrerPolicy="no-referrer">
+        </div>
+    </div>
+</header>
 
-    <!-- Curated Essentials Section -->
-    <section class="py-24 bg-white">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-end mb-16 gap-6">
-                <div class="max-w-2xl">
-                    <h2 class="text-primary/60 font-bold tracking-widest text-sm uppercase mb-2">The Collection</h2>
-                    <h3 class="text-4xl font-bold text-primary tracking-tight">Curated Essentials</h3>
-                </div>
-                <a class="text-primary font-bold flex items-center gap-2 hover:gap-4 transition-all" href="#">
-                    View All Products <span class="material-symbols-outlined">arrow_forward</span>
-                </a>
+<!-- Curated Essentials Section -->
+<section class="py-24 bg-white">
+    <div class="max-w-7xl mx-auto px-6 md:px-12">
+        <div class="flex flex-col md:flex-row justify-between items-end mb-16 gap-6">
+            <div class="max-w-2xl">
+                <h2 class="text-primary/60 font-bold tracking-widest text-sm uppercase mb-2">{{ curated.eyebrow }}</h2>
+                <h3 class="text-4xl font-bold text-primary tracking-tight">{{ curated.heading }}</h3>
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-4 md:grid-rows-2 gap-6 h-full md:h-[800px]">
-                <!-- Main Featured -->
-                <div class="md:col-span-2 md:row-span-2 bg-surface-container-low rounded-2xl overflow-hidden relative group cursor-pointer">
-                    <img class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" alt="Dinnerware Sets" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBXRm5EWDyFJhycRxa05qHk_2Uj4eKuQF6zAYY3WchOYHlz-X-akt09RbCshc3PNQyT7DTENuwprGLo6nI-aLQ7sSZf9AWNzBJyvs8Cz5C9myBzI28n3xxTTQVZYOcoU05aDn0XKadA9oSFiVBO0LlZqSrhEuIp5zOCYpqKonE6XJHA2sVHtuX5ChYbwkpiyyOig765WNBKj8yYI-r8O-qfIcvukOp8hGvS1OVhrFiZzv0CHK0a3F-wjT5qdXsumHBDAp0R754aSrVX" referrerPolicy="no-referrer">
-                    <div class="absolute inset-0 bg-gradient-to-t from-primary/60 to-transparent flex flex-col justify-end p-8">
-                        <span class="text-on-primary-container bg-primary-container px-3 py-1 rounded-full text-xs font-bold w-fit mb-3">Bestseller</span>
-                        <h4 class="text-3xl font-bold text-white mb-2">Dinnerware Sets</h4>
-                        <p class="text-white/80 text-sm">Perfect for eco-conscious hosting and premium events.</p>
-                    </div>
+            <a class="text-primary font-bold flex items-center gap-2 hover:gap-4 transition-all" href="{{ curated.view_all_url | relative_url }}">
+                {{ curated.view_all_label }} <span class="material-symbols-outlined">arrow_forward</span>
+            </a>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-4 md:grid-rows-2 gap-6 h-full md:h-[800px]">
+            <!-- Featured (large) -->
+            <div class="md:col-span-2 md:row-span-2 bg-surface-container-low rounded-2xl overflow-hidden relative group cursor-pointer">
+                <img class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" alt="{{ curated.featured.title }}" src="{{ curated.featured.image | relative_url }}" referrerPolicy="no-referrer">
+                <div class="absolute inset-0 bg-gradient-to-t from-primary/60 to-transparent flex flex-col justify-end p-8">
+                    {% if curated.featured.badge and curated.featured.badge != "" %}
+                    <span class="text-on-primary-container bg-primary-container px-3 py-1 rounded-full text-xs font-bold w-fit mb-3">{{ curated.featured.badge }}</span>
+                    {% endif %}
+                    <h4 class="text-3xl font-bold text-white mb-2">{{ curated.featured.title }}</h4>
+                    <p class="text-white/80 text-sm">{{ curated.featured.description }}</p>
                 </div>
-                <!-- Secondary 1 -->
-                <div class="md:col-span-2 md:row-span-1 bg-surface-container-high rounded-2xl overflow-hidden relative group cursor-pointer">
-                    <img class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" alt="Artisan Bowls" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDMn7AyQeNXL-yurJ9sZvU3UqEGOqXJfP0xuZ_xvp7t85O9y4h3arfAVRKOQWyRFQ2FrJvOuFAA0Mj7jF2sBEkG8gjaeZR_A5evgBwELL-SrL709SZImxVMlAdf5lQCQyC9YyobDWQcTvoPMflPhLBgMZiTmfgctlt3wZpqSrrAPRj2aO82ahOdRmJwn2R2OWUtnjITkeF_XgYPVeUWyuO3fb_ZezvjVF4CCPR6pF9ZDUd0OT2y_ruCJ8PoD7vcqQ5xc4_imEvGkyet" referrerPolicy="no-referrer">
-                    <div class="absolute inset-0 bg-black/10 group-hover:bg-black/20 transition-colors flex flex-col justify-end p-6">
-                        <h4 class="text-2xl font-bold text-white">Artisan Bowls</h4>
-                    </div>
+            </div>
+            <!-- Secondary (wide) -->
+            <div class="md:col-span-2 md:row-span-1 bg-surface-container-high rounded-2xl overflow-hidden relative group cursor-pointer">
+                <img class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" alt="{{ curated.secondary.title }}" src="{{ curated.secondary.image | relative_url }}" referrerPolicy="no-referrer">
+                <div class="absolute inset-0 bg-black/10 group-hover:bg-black/20 transition-colors flex flex-col justify-end p-6">
+                    <h4 class="text-2xl font-bold text-white">{{ curated.secondary.title }}</h4>
                 </div>
-                <!-- Small 1 -->
-                <div class="md:col-span-1 md:row-span-1 bg-surface-container-highest rounded-2xl overflow-hidden relative group cursor-pointer">
-                    <img class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" alt="Natural Utensils" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCIuiGaDabI9QcwjTySRoxIgPZRJgLJO3vrwsxSow8D5odrdUH2nVxXSPPVS5_Jvc-D8_QZ2fSdJ1esT1ITrUnym4UsDMctQwdndABKFpLW5fnwqkxOz29uMtf1r_wWu2ogRcdQ0EuwEAn4Z3tPbv-eW413Xc9meisaxve_LWJcravOkC4B3Z2fUC94_aI9ZLDRLytLwD4vWt78qSEw4zmLooNOl61HXebS2LkFpI_QT71ZMBDNBw_3C-lZgUWwXM9NjhxvW8hCajeR" referrerPolicy="no-referrer">
-                    <div class="absolute inset-0 flex flex-col justify-end p-6">
-                        <h4 class="text-xl font-bold text-primary">Natural Utensils</h4>
-                    </div>
+            </div>
+            <!-- Small (image card) -->
+            <div class="md:col-span-1 md:row-span-1 bg-surface-container-highest rounded-2xl overflow-hidden relative group cursor-pointer">
+                <img class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700" alt="{{ curated.small.title }}" src="{{ curated.small.image | relative_url }}" referrerPolicy="no-referrer">
+                <div class="absolute inset-0 flex flex-col justify-end p-6">
+                    <h4 class="text-xl font-bold text-primary">{{ curated.small.title }}</h4>
                 </div>
-                <!-- Small 2 -->
-                <div class="md:col-span-1 md:row-span-1 bg-secondary-container rounded-2xl flex flex-col justify-center items-center p-8 text-center group cursor-pointer hover:bg-secondary-container/80 transition-colors">
-                    <div class="w-16 h-16 rounded-full bg-primary flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                        <span class="material-symbols-outlined text-white text-3xl">eco</span>
-                    </div>
-                    <h4 class="text-lg font-bold text-primary mb-2">Custom Orders</h4>
-                    <p class="text-sm text-secondary">Wholesale solutions for your brand.</p>
+            </div>
+            <!-- Custom Orders (icon card, no image) -->
+            <div class="md:col-span-1 md:row-span-1 bg-secondary-container rounded-2xl flex flex-col justify-center items-center p-8 text-center group cursor-pointer hover:bg-secondary-container/80 transition-colors">
+                <div class="w-16 h-16 rounded-full bg-primary flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                    <span class="material-symbols-outlined text-white text-3xl">{{ curated.custom.icon }}</span>
                 </div>
+                <h4 class="text-lg font-bold text-primary mb-2">{{ curated.custom.title }}</h4>
+                <p class="text-sm text-secondary">{{ curated.custom.description }}</p>
             </div>
         </div>
-    </section>
+    </div>
+</section>
 
-    <!-- Heritage Section -->
-    <section class="py-24 bg-surface-container-low relative overflow-hidden">
-        <div class="max-w-7xl mx-auto px-6 md:px-12 relative z-10">
-            <div class="grid grid-cols-1 md:grid-cols-12 gap-12 items-center">
-                <div class="md:col-span-5">
-                    <div class="relative">
-                        <img class="rounded-2xl editorial-shadow transform -rotate-3 w-full" alt="Palm Plantation" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCd5-EPeM73gZftd4jkoyZaT3wjae4thy_tvHlE0XvZ7_xjjQ5sREcbMu102_5sDO49-jUupW7PPcJzvRZMmv0kDMqXMOVFaZci7xdpEJ371-K5QQgXYSEx_HlSmZgKLjEt9SG39MnU4Ekm32lbFp9UqHSy-UW0rn1U8Hnu3jEbCkzV6grckPap5IcaYE2zjUFxo1wkVYm2cmkKyHdKG31nzYFb-8ZNirqkipebn2vwHKnJhn2OoEgGgkSrTOrFe0rh7QhWNZ-1wLch" referrerPolicy="no-referrer">
-                        <div class="absolute -bottom-6 -right-6 w-48 h-48 bg-primary rounded-2xl hidden md:flex items-center justify-center p-6 text-on-primary text-center leading-tight font-bold editorial-shadow">
-                            100% Home Compostable
-                        </div>
+<!-- Heritage Section -->
+<section class="py-24 bg-surface-container-low relative overflow-hidden">
+    <div class="max-w-7xl mx-auto px-6 md:px-12 relative z-10">
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-12 items-center">
+            <div class="md:col-span-5">
+                <div class="relative">
+                    <img class="rounded-2xl editorial-shadow transform -rotate-3 w-full" alt="{{ heritage.image_alt }}" src="{{ heritage.image | relative_url }}" referrerPolicy="no-referrer">
+                    {% if heritage.badge and heritage.badge != "" %}
+                    <div class="absolute -bottom-6 -right-6 w-48 h-48 bg-primary rounded-2xl hidden md:flex items-center justify-center p-6 text-on-primary text-center leading-tight font-bold editorial-shadow">
+                        {{ heritage.badge }}
                     </div>
+                    {% endif %}
                 </div>
-                <div class="md:col-span-6 md:col-start-7">
-                    <h2 class="text-primary/60 font-bold tracking-widest text-sm uppercase mb-4">Our Heritage</h2>
-                    <h3 class="text-5xl font-extrabold text-primary mb-8 tracking-tight">Born from the Earth</h3>
-                    <div class="space-y-6 text-on-surface-variant text-lg leading-relaxed">
-                        <p>
-                            DineStar began with a simple observation: nature already creates the perfect container. We harvest naturally fallen leaves from the Areca palm, ensuring no trees are ever cut down.
-                        </p>
-                        <p>
-                            Each piece is sterilized and heat-pressed using pure steam. No chemicals, no glues, no toxins. Just the raw, textured beauty of the palm leaf, preserved for your table.
-                        </p>
-                        <ul class="grid grid-cols-2 gap-4 mt-8">
-                            <li class="flex items-center gap-3 text-primary font-semibold">
-                                <span class="material-symbols-outlined text-tertiary">check_circle</span> Zero Chemicals
-                            </li>
-                            <li class="flex items-center gap-3 text-primary font-semibold">
-                                <span class="material-symbols-outlined text-tertiary">check_circle</span> Microwavable
-                            </li>
-                            <li class="flex items-center gap-3 text-primary font-semibold">
-                                <span class="material-symbols-outlined text-tertiary">check_circle</span> Water Resistant
-                            </li>
-                            <li class="flex items-center gap-3 text-primary font-semibold">
-                                <span class="material-symbols-outlined text-tertiary">check_circle</span> Oven Safe
-                            </li>
-                            <li class="flex items-center gap-3 text-primary font-semibold">
-                                <span class="material-symbols-outlined text-tertiary">check_circle</span> Refrigerator safe
-                            </li>
-                        </ul>
-                    </div>
+            </div>
+            <div class="md:col-span-6 md:col-start-7">
+                <h2 class="text-primary/60 font-bold tracking-widest text-sm uppercase mb-4">{{ heritage.eyebrow }}</h2>
+                <h3 class="text-5xl font-extrabold text-primary mb-8 tracking-tight">{{ heritage.heading }}</h3>
+                <div class="space-y-6 text-on-surface-variant text-lg leading-relaxed">
+                    {% for p in heritage.paragraphs %}
+                    <p>{{ p }}</p>
+                    {% endfor %}
+                    <ul class="grid grid-cols-2 gap-4 mt-8">
+                        {% for feature in heritage.features %}
+                        <li class="flex items-center gap-3 text-primary font-semibold">
+                            <span class="material-symbols-outlined text-tertiary">check_circle</span> {{ feature }}
+                        </li>
+                        {% endfor %}
+                    </ul>
                 </div>
             </div>
         </div>
-    </section>
+    </div>
+</section>
 
-    <!-- CTA Section -->
-    <section class="py-24 bg-white overflow-hidden">
-        <div class="max-w-5xl mx-auto px-6 md:px-12">
-            <div class="bg-primary rounded-[2rem] p-12 md:p-20 relative overflow-hidden flex flex-col items-center text-center">
-                <div class="absolute top-0 right-0 w-64 h-64 bg-primary-container/20 rounded-full blur-3xl -mr-20 -mt-20"></div>
-                <div class="absolute bottom-0 left-0 w-64 h-64 bg-tertiary/20 rounded-full blur-3xl -ml-20 -mb-20"></div>
-                <h2 class="text-4xl md:text-5xl font-extrabold text-white mb-6 relative z-10">Ready to Elevate Your Table?</h2>
-                <p class="text-on-primary-container text-lg mb-10 max-w-2xl relative z-10 leading-relaxed">
-                    Join the sustainable luxury movement. Whether it's an intimate dinner or a grand event, DineStar provides the organic touch your guests will remember.
-                </p>
-                <div class="flex flex-col sm:flex-row gap-4 relative z-10">
-                    <button class="px-10 py-4 bg-surface text-primary rounded-xl font-bold text-lg hover:bg-surface-bright transition-colors editorial-shadow">
-                        Shop Now
-                    </button>
-                    <button class="px-10 py-4 border-2 border-on-primary-container text-on-primary-container rounded-xl font-bold text-lg hover:bg-white/10 transition-colors">
-                        Request Sample Kit
-                    </button>
-                </div>
+<!-- CTA Section -->
+<section class="py-24 bg-white overflow-hidden">
+    <div class="max-w-5xl mx-auto px-6 md:px-12">
+        <div class="bg-primary rounded-[2rem] p-12 md:p-20 relative overflow-hidden flex flex-col items-center text-center">
+            <div class="absolute top-0 right-0 w-64 h-64 bg-primary-container/20 rounded-full blur-3xl -mr-20 -mt-20"></div>
+            <div class="absolute bottom-0 left-0 w-64 h-64 bg-tertiary/20 rounded-full blur-3xl -ml-20 -mb-20"></div>
+            <h2 class="text-4xl md:text-5xl font-extrabold text-white mb-6 relative z-10">{{ cta.heading }}</h2>
+            <p class="text-on-primary-container text-lg mb-10 max-w-2xl relative z-10 leading-relaxed">
+                {{ cta.description }}
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 relative z-10">
+                <button class="px-10 py-4 bg-surface text-primary rounded-xl font-bold text-lg hover:bg-surface-bright transition-colors editorial-shadow">
+                    {{ cta.primary_button }}
+                </button>
+                <button class="px-10 py-4 border-2 border-on-primary-container text-on-primary-container rounded-xl font-bold text-lg hover:bg-white/10 transition-colors">
+                    {{ cta.secondary_button }}
+                </button>
             </div>
         </div>
-    </section>
+    </div>
+</section>


### PR DESCRIPTION
…ions

New _data/ files for sections previously hardcoded in templates:
- footer.yml: tagline, social icons, two link columns, copyright, certification badges
- contact.yml: heading, contact-info items (icon/color/label/value), business hours
- about.yml: story (heading, paragraphs, image, stat overlay), values (heading, 3 cards)

Extended _data/home.yml with three more sections beyond hero:
- curated_essentials: featured/secondary/small/custom card content
- heritage: paragraphs, image, badge, feature bullets
- cta: heading, description, button labels

Templates rewritten to consume the data:
- _includes/footer.html now loops over footer.yml
- contact.html, about.html now read from their data files
- index.html curated/heritage/CTA sections now data-driven

admin/config.yml gained collections for all new files. Editor sees a clear per-page list in the CMS sidebar; each page expands into the right object/list widgets for its sub-sections. Color-themed elements (service icons, contact info badges) use a select widget so the editor picks from valid options instead of free-text-typing a token.