### PR TITLE
Fix CMS config YAML: drop bare double-quotes inside flow maps

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -43,8 +43,8 @@ collections:
             fields:
               - { label: Eyebrow, name: eyebrow, widget: string }
               - { label: Heading, name: heading, widget: string }
-              - { label: "View all" link label, name: view_all_label, widget: string }
-              - { label: "View all" link URL, name: view_all_url, widget: string, hint: "e.g. /products.html or # for none" }
+              - { label: View-all link label, name: view_all_label, widget: string }
+              - { label: View-all link URL, name: view_all_url, widget: string, hint: "e.g. /products.html or # for none" }
               - label: Featured card (large)
                 name: featured
                 widget: object
@@ -153,7 +153,7 @@ collections:
                 field: { label: Paragraph, name: paragraph, widget: text }
               - { label: Image, name: image, widget: image }
               - { label: Image alt text, name: image_alt, widget: string }
-              - { label: Stat number (e.g. "10+"), name: stat_number, widget: string }
+              - { label: Stat number, name: stat_number, widget: string, hint: 'e.g. 10+' }
               - { label: Stat label, name: stat_label, widget: string }
           - label: Values section
             name: values
@@ -187,7 +187,7 @@ collections:
                 widget: select
                 options: [primary, secondary, tertiary, surface]
                 default: primary
-              - { label: Label (e.g. "Phone Number"), name: label, widget: string }
+              - { label: Label, name: label, widget: string, hint: 'e.g. Phone Number' }
               - { label: Value (the actual address/number/email), name: value, widget: string }
           - { label: Business hours heading, name: hours_heading, widget: string }
           - label: Business hours


### PR DESCRIPTION
Three field labels had inline double-quoted phrases inside YAML flow map syntax (e.g. { label: "View all" link label, ... }), which the parser reads as a quoted string followed by stray tokens — Decap refused to load with YAMLSemanticError "Separator , missing in flow map".

Reworded the labels to drop the inner quotes; moved example values into a `hint:` field where they belong anyway.