### PR TITLE
Fix CMS config: drop bare quoted phrases inside about description

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -140,7 +140,7 @@ collections:
       - file: _data/about.yml
         name: about
         label: About page
-        description: "Our Story" and "Our Core Values" sections.
+        description: Our Story and Our Core Values sections.
         fields:
           - label: Story section
             name: story


### PR DESCRIPTION
Same flaw as the previous label fixes: an unquoted YAML scalar that contained "Our Story" and "Our Core Values" in inline double quotes was parsed as multiple disjoint tokens, breaking the parent map's indentation tracking. Reworded to plain text.

Validated the whole file with js-yaml before pushing this time.