### PR TITLE
Wire up dead hero/CTA buttons as links

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@ nav_active: home
                 <a href="{{ curated.view_all_url | relative_url }}" class="px-8 py-4 organic-gradient text-on-primary rounded-3xl font-bold text-lg hover:scale-105 transition-transform editorial-shadow">
                     {{ hero.primary_button }}
                 </a>
-                <button class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
+                <a href="{{ '/about.html' | relative_url }}" class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
                     {{ hero.secondary_button }}
-                </button>
+                </a>
             </div>
         </div>
         <div class="relative group">
@@ -130,12 +130,12 @@ nav_active: home
                 {{ cta.description }}
             </p>
             <div class="flex flex-col sm:flex-row gap-4 relative z-10">
-                <button class="px-10 py-4 bg-surface text-primary rounded-xl font-bold text-lg hover:bg-surface-bright transition-colors editorial-shadow">
+                <a href="{{ '/products.html' | relative_url }}" class="px-10 py-4 bg-surface text-primary rounded-xl font-bold text-lg hover:bg-surface-bright transition-colors editorial-shadow">
                     {{ cta.primary_button }}
-                </button>
-                <button class="px-10 py-4 border-2 border-on-primary-container text-on-primary-container rounded-xl font-bold text-lg hover:bg-white/10 transition-colors">
+                </a>
+                <a href="{{ '/contact.html' | relative_url }}" class="px-10 py-4 border-2 border-on-primary-container text-on-primary-container rounded-xl font-bold text-lg hover:bg-white/10 transition-colors">
                     {{ cta.secondary_button }}
-                </button>
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Convert inert <button> elements to anchors:
- hero "Our Story" -> /about.html
- CTA "Shop Now" -> /products.html
- CTA "Request Sample Kit" -> /contact.html

Only the contact-form submit and mobile-menu toggle remain as buttons.