### PR TITLE
Expand CMS coverage to previously hardcoded content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,14 +3,6 @@ description: Sustainable Palm Leaf Dinnerware - Nature's Craft for Your Table.
 url: https://ajithsinghsajitha.github.io
 baseurl: /dinestar
 
-nav:
-  - { title: Home,         url: /index.html,    slug: home }
-  - { title: Products,     url: /products.html, slug: products }
-  - { title: Our Services, url: /services.html, slug: services }
-  - { title: About Us,     url: /about.html,    slug: about }
-  - { title: Brochure,     url: /brochure.html, slug: brochure }
-  - { title: Contact Us,   url: /contact.html,  slug: contact }
-
 exclude:
   - README.md
   - .claude

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -1,6 +1,23 @@
 heading: Get in Touch
 subheading: Have questions about our products or services? We're here to help you transition to a more sustainable table.
 
+form:
+  name_label: Full Name
+  name_placeholder: John Doe
+  email_label: Email Address
+  email_placeholder: john@example.com
+  subject_label: Subject
+  subjects:
+    - General Inquiry
+    - Wholesale Request
+    - Event Catering
+    - Custom Branding
+  message_label: Message
+  message_placeholder: How can we help you?
+  submit_label: Send Message
+
+info_heading: Contact Information
+
 info:
   - icon: location_on
     color: primary

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,3 +1,4 @@
+brand_name: DineStar
 tagline: Redefining dinnerware through the wisdom of nature. Premium palm leaf containers for a sustainable future.
 
 social:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,7 @@
+items:
+  - { title: Home,         url: /index.html,    slug: home }
+  - { title: Products,     url: /products.html, slug: products }
+  - { title: Our Services, url: /services.html, slug: services }
+  - { title: About Us,     url: /about.html,    slug: about }
+  - { title: Brochure,     url: /brochure.html, slug: brochure }
+  - { title: Contact Us,   url: /contact.html,  slug: contact }

--- a/_data/products.yml
+++ b/_data/products.yml
@@ -1,3 +1,5 @@
+heading: Our Collection
+intro: Explore our range of premium, sustainable palm leaf dinnerware designed for every occasion.
 items:
   - name: "6'' "
     description: Round Deep plate

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,3 +1,5 @@
+heading: Our Services
+intro: Beyond products, we offer comprehensive solutions for businesses and events looking to make a sustainable impact.
 items:
   - title: Eco Packaging Consulting
     description: We provide bulk dinnerware and customized setups for weddings,

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 px-6 md:px-12 py-16 max-w-7xl mx-auto">
         <div class="space-y-6">
             <div class="flex items-center gap-3">
-                <span class="text-2xl font-bold text-primary tracking-tight">DineStar</span>
+                <span class="text-2xl font-bold text-primary tracking-tight">{{ f.brand_name }}</span>
             </div>
             <p class="text-secondary leading-relaxed max-w-xs">
                 {{ f.tagline }}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,7 +4,7 @@
             <img alt="DineStar Logo" class="h-20 w-auto object-contain" src="{{ '/assets/images/ds-logo.svg' | relative_url }}">
         </a>
         <div class="hidden md:flex items-center gap-8">
-            {% for item in site.nav %}
+            {% for item in site.data.navigation.items %}
                 {% if item.slug == page.nav_active %}
                     <a class="text-primary font-bold border-b-2 border-primary pb-1 text-sm tracking-wide" href="{{ item.url | relative_url }}">{{ item.title }}</a>
                 {% else %}
@@ -21,7 +21,7 @@
     <!-- Mobile menu panel -->
     <div id="mobile-menu" class="hidden md:hidden border-t border-outline-variant/10 bg-surface/95 glass-nav">
         <div class="flex flex-col px-6 py-4 gap-1">
-            {% for item in site.nav %}
+            {% for item in site.data.navigation.items %}
                 {% if item.slug == page.nav_active %}
                     <a class="text-primary font-bold py-3 text-base tracking-wide" href="{{ item.url | relative_url }}">{{ item.title }}</a>
                 {% else %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -19,6 +19,20 @@ collections:
     label: Site content
     description: Edit the text and images on each page.
     files:
+      - file: _data/navigation.yml
+        name: navigation
+        label: Navigation menu
+        description: The links in the top navigation bar. Add, remove, or reorder them.
+        fields:
+          - label: Menu items
+            name: items
+            widget: list
+            summary: "{{fields.title}}"
+            fields:
+              - { label: Label, name: title, widget: string }
+              - { label: URL, name: url, widget: string, hint: "e.g. /products.html" }
+              - { label: Page slug (for active-link highlighting), name: slug, widget: string, required: false, hint: "Matches the page's nav_active; leave blank if unsure" }
+
       - file: _data/home.yml
         name: home
         label: Home page
@@ -103,8 +117,10 @@ collections:
       - file: _data/products.yml
         name: products
         label: Products
-        description: Cards shown on the Products page. Add, remove, or reorder them.
+        description: Page heading and the product cards. Add, remove, or reorder cards.
         fields:
+          - { label: Page heading, name: heading, widget: string }
+          - { label: Page intro text, name: intro, widget: text }
           - label: Products
             name: items
             widget: list
@@ -118,8 +134,10 @@ collections:
       - file: _data/services.yml
         name: services
         label: Services
-        description: Service items on the Our Services page.
+        description: Page heading and the service items on the Our Services page.
         fields:
+          - { label: Page heading, name: heading, widget: string }
+          - { label: Page intro text, name: intro, widget: text }
           - label: Services
             name: items
             widget: list
@@ -172,10 +190,27 @@ collections:
       - file: _data/contact.yml
         name: contact
         label: Contact page
-        description: Contact info and business hours (the form itself is fixed).
+        description: Page heading, the enquiry form labels, contact info, and business hours.
         fields:
           - { label: Heading, name: heading, widget: string }
           - { label: Subheading, name: subheading, widget: text }
+          - label: Enquiry form
+            name: form
+            widget: object
+            fields:
+              - { label: Name field label, name: name_label, widget: string }
+              - { label: Name field placeholder, name: name_placeholder, widget: string }
+              - { label: Email field label, name: email_label, widget: string }
+              - { label: Email field placeholder, name: email_placeholder, widget: string }
+              - { label: Subject field label, name: subject_label, widget: string }
+              - label: Subject dropdown options
+                name: subjects
+                widget: list
+                field: { label: Option, name: option, widget: string }
+              - { label: Message field label, name: message_label, widget: string }
+              - { label: Message field placeholder, name: message_placeholder, widget: string }
+              - { label: Submit button label, name: submit_label, widget: string }
+          - { label: Contact info heading, name: info_heading, widget: string }
           - label: Contact info items
             name: info
             widget: list
@@ -218,8 +253,9 @@ collections:
       - file: _data/footer.yml
         name: footer
         label: Footer
-        description: Tagline, social links, and link columns shown at the bottom of every page.
+        description: Brand name, tagline, social links, and link columns shown at the bottom of every page.
         fields:
+          - { label: Brand name, name: brand_name, widget: string }
           - { label: Tagline, name: tagline, widget: text }
           - label: Social icon links
             name: social

--- a/contact.html
+++ b/contact.html
@@ -23,29 +23,28 @@ nav_active: contact
                     <input type="checkbox" name="botcheck" class="hidden" style="display:none" tabindex="-1" autocomplete="off">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
-                            <label class="block text-sm font-bold text-primary mb-2" for="name">Full Name</label>
-                            <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="name" name="name" placeholder="John Doe" type="text" required>
+                            <label class="block text-sm font-bold text-primary mb-2" for="name">{{ c.form.name_label }}</label>
+                            <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="name" name="name" placeholder="{{ c.form.name_placeholder }}" type="text" required>
                         </div>
                         <div>
-                            <label class="block text-sm font-bold text-primary mb-2" for="email">Email Address</label>
-                            <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="email" name="email" placeholder="john@example.com" type="email" required>
+                            <label class="block text-sm font-bold text-primary mb-2" for="email">{{ c.form.email_label }}</label>
+                            <input class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="email" name="email" placeholder="{{ c.form.email_placeholder }}" type="email" required>
                         </div>
                     </div>
                     <div>
-                        <label class="block text-sm font-bold text-primary mb-2" for="enquiry-type">Subject</label>
+                        <label class="block text-sm font-bold text-primary mb-2" for="enquiry-type">{{ c.form.subject_label }}</label>
                         <select class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all" id="enquiry-type" name="enquiry_type">
-                            <option>General Inquiry</option>
-                            <option>Wholesale Request</option>
-                            <option>Event Catering</option>
-                            <option>Custom Branding</option>
+                            {% for option in c.form.subjects %}
+                            <option>{{ option }}</option>
+                            {% endfor %}
                         </select>
                     </div>
                     <div>
-                        <label class="block text-sm font-bold text-primary mb-2" for="message">Message</label>
-                        <textarea class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all h-32" id="message" name="message" placeholder="How can we help you?" required></textarea>
+                        <label class="block text-sm font-bold text-primary mb-2" for="message">{{ c.form.message_label }}</label>
+                        <textarea class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all h-32" id="message" name="message" placeholder="{{ c.form.message_placeholder }}" required></textarea>
                     </div>
                     <button id="contact-submit" class="w-full py-4 organic-gradient text-on-primary rounded-xl font-bold text-lg hover:scale-[1.02] transition-transform editorial-shadow disabled:opacity-60 disabled:cursor-not-allowed" type="submit">
-                        Send Message
+                        {{ c.form.submit_label }}
                     </button>
                     <p id="contact-status" class="text-center font-semibold hidden" role="status" aria-live="polite"></p>
                 </form>
@@ -54,7 +53,7 @@ nav_active: contact
             <!-- Contact Info -->
             <div class="flex flex-col justify-center space-y-12">
                 <div>
-                    <h3 class="text-2xl font-bold text-primary mb-6">Contact Information</h3>
+                    <h3 class="text-2xl font-bold text-primary mb-6">{{ c.info_heading }}</h3>
                     <div class="space-y-6">
                         {% for item in c.info %}
                         <div class="flex items-center gap-4">

--- a/products.html
+++ b/products.html
@@ -6,8 +6,8 @@ nav_active: products
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <header class="mb-16">
-            <h1 class="text-5xl font-extrabold text-primary mb-4 tracking-tight">Our Collection</h1>
-            <p class="text-lg text-on-surface-variant max-w-2xl">Explore our range of premium, sustainable palm leaf dinnerware designed for every occasion.</p>
+            <h1 class="text-5xl font-extrabold text-primary mb-4 tracking-tight">{{ site.data.products.heading }}</h1>
+            <p class="text-lg text-on-surface-variant max-w-2xl">{{ site.data.products.intro }}</p>
         </header>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/services.html
+++ b/services.html
@@ -6,8 +6,8 @@ nav_active: services
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <header class="mb-16 text-center">
-            <h1 class="text-5xl font-extrabold text-primary mb-4 tracking-tight">Our Services</h1>
-            <p class="text-lg text-on-surface-variant max-w-2xl mx-auto">Beyond products, we offer comprehensive solutions for businesses and events looking to make a sustainable impact.</p>
+            <h1 class="text-5xl font-extrabold text-primary mb-4 tracking-tight">{{ site.data.services.heading }}</h1>
+            <p class="text-lg text-on-surface-variant max-w-2xl mx-auto">{{ site.data.services.intro }}</p>
         </header>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-12">


### PR DESCRIPTION
Move hardcoded template strings into _data so editors can change them via Decap CMS, and add matching fields to admin/config.yml:

- Products & Services: page heading + intro text
- Contact: form field labels, placeholders, subject dropdown options, submit button label, and the "Contact Information" heading
- Footer: brand name
- Navigation: moved the top menu from _config.yml into _data/navigation.yml as an editable list (new CMS collection); nav.html now reads site.data.navigation.items

All YAML files validated with js-yaml.