### PR TITLE
Remove branding-related content (supply-only business)

### DIFF
--- a/_data/brochure.yml
+++ b/_data/brochure.yml
@@ -1,5 +1,5 @@
 heading: Digital Brochure
-subheading: Download our latest catalog to see our full range of sustainable dinnerware and custom solutions.
+subheading: Download our latest catalog to see our full range of sustainable dinnerware.
 collection_title: DineStar 2024 Collection
 collection_description: Our comprehensive brochure includes detailed specifications, material origins, and a complete product list. Perfect for event planners and business owners.
 features:

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -11,7 +11,6 @@ form:
     - General Inquiry
     - Wholesale Request
     - Event Catering
-    - Custom Branding
   message_label: Message
   message_placeholder: How can we help you?
   submit_label: Send Message

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -26,8 +26,8 @@ curated_essentials:
     image: https://lh3.googleusercontent.com/aida-public/AB6AXuCIuiGaDabI9QcwjTySRoxIgPZRJgLJO3vrwsxSow8D5odrdUH2nVxXSPPVS5_Jvc-D8_QZ2fSdJ1esT1ITrUnym4UsDMctQwdndABKFpLW5fnwqkxOz29uMtf1r_wWu2ogRcdQ0EuwEAn4Z3tPbv-eW413Xc9meisaxve_LWJcravOkC4B3Z2fUC94_aI9ZLDRLytLwD4vWt78qSEw4zmLooNOl61HXebS2LkFpI_QT71ZMBDNBw_3C-lZgUWwXM9NjhxvW8hCajeR
   custom:
     icon: eco
-    title: Custom Orders
-    description: Wholesale solutions for your brand.
+    title: Bulk Orders
+    description: Wholesale supply for your business.
 heritage:
   eyebrow: Our Heritage
   heading: Born from the Earth

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -7,12 +7,6 @@ items:
       and eco- friendly.
     icon: event
     color: primary
-  - title: Custom Packaging Solutions
-    description: "Elevate your brand with custom-stamped palm leaf products like
-      bundled products (plates + cutlery + containers), Event kits, Catering
-      packs, etc "
-    icon: branding_watermark
-    color: secondary
   - title: "Logistics and Delivery Support "
     description: Local delivery and Bulk shipment coordination
     icon: inventory


### PR DESCRIPTION
DineStar supplies products and does not offer branding services:
- drop the "Custom Packaging Solutions" service (brand-stamping)
- remove "Custom Branding" from the contact subject dropdown
- reword home card "Custom Orders / for your brand" -> "Bulk Orders / Wholesale supply for your business"
- drop "and custom solutions" from the brochure subheading