### PR TITLE
Change CTA secondary button to "Request a Quote"

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -53,4 +53,4 @@ cta:
     dinner or a grand event, DineStar provides the organic touch your guests
     will remember.
   primary_button: Shop Now
-  secondary_button: Request Sample Kit
+  secondary_button: Request a Quote


### PR DESCRIPTION
"Request Sample Kit" doesn't fit a wholesale supply business; a quote request is the natural secondary action and already links to /contact.