### PR TITLE
Theme the Decap CMS admin UI

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -5,6 +5,81 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex">
     <title>DineStar Content Manager</title>
+    <link rel="icon" type="image/svg+xml" href="https://ajithsinghsajitha.github.io/dinestar/assets/images/ds-logo.svg">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=block" rel="stylesheet">
+    <style>
+        :root {
+            --ds-primary: #0b4211;
+            --ds-accent: #265a26;
+            --ds-surface: #fafbea;
+            --ds-chip: #e3e6bb;
+            --ds-border: #e2e4d4;
+        }
+
+        /* App background */
+        body,
+        [class*="AppMainContainer"],
+        [class*="AppRoot"],
+        [class*="AppHeader"] {
+            background-color: var(--ds-surface) !important;
+        }
+
+        /* Collection cards in the grid view */
+        [class*="ListCard"] {
+            position: relative !important;
+            border-radius: 14px !important;
+            border: 1px solid var(--ds-border) !important;
+            border-left: 5px solid var(--ds-primary) !important;
+            box-shadow: 0 4px 14px rgba(11, 66, 17, 0.07) !important;
+            transition: transform 0.15s ease, box-shadow 0.15s ease !important;
+            overflow: hidden !important;
+        }
+        [class*="ListCard"]:hover {
+            transform: translateY(-3px) !important;
+            box-shadow: 0 12px 26px rgba(11, 66, 17, 0.16) !important;
+        }
+
+        /* Card title + a leading icon chip */
+        [class*="ListCardTitle"] {
+            color: var(--ds-primary) !important;
+            font-weight: 700 !important;
+            display: flex !important;
+            align-items: center !important;
+        }
+        [class*="ListCardTitle"]::before {
+            font-family: 'Material Symbols Outlined';
+            font-weight: normal;
+            font-style: normal;
+            font-size: 26px;
+            line-height: 1;
+            letter-spacing: normal;
+            text-transform: none;
+            white-space: nowrap;
+            -webkit-font-feature-settings: 'liga';
+            -webkit-font-smoothing: antialiased;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 46px;
+            height: 46px;
+            margin-right: 14px;
+            flex: 0 0 auto;
+            border-radius: 12px;
+            background: var(--ds-chip);
+            color: var(--ds-accent);
+            content: 'edit_document'; /* default fallback for any card */
+        }
+
+        /* Per-card icons — order matches the files in admin/config.yml */
+        [class*="ListCard"]:nth-of-type(1) [class*="ListCardTitle"]::before { content: 'menu'; }            /* Navigation menu */
+        [class*="ListCard"]:nth-of-type(2) [class*="ListCardTitle"]::before { content: 'home'; }            /* Home page */
+        [class*="ListCard"]:nth-of-type(3) [class*="ListCardTitle"]::before { content: 'restaurant'; }      /* Products */
+        [class*="ListCard"]:nth-of-type(4) [class*="ListCardTitle"]::before { content: 'handshake'; }       /* Services */
+        [class*="ListCard"]:nth-of-type(5) [class*="ListCardTitle"]::before { content: 'info'; }            /* About page */
+        [class*="ListCard"]:nth-of-type(6) [class*="ListCardTitle"]::before { content: 'mail'; }            /* Contact page */
+        [class*="ListCard"]:nth-of-type(7) [class*="ListCardTitle"]::before { content: 'picture_as_pdf'; }  /* Brochure page */
+        [class*="ListCard"]:nth-of-type(8) [class*="ListCardTitle"]::before { content: 'web_asset'; }       /* Footer */
+    </style>
 </head>
 <body>
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>


### PR DESCRIPTION
Inject custom CSS into admin/index.html to fix the bare collection cards: brand-green accent border, rounded cards, hover lift, and a Material Symbols icon chip on each card (per-card icons mapped to the config file order, with a default icon fallback). Also brand the app background and add a favicon.

Decap has no custom-card API, so this targets its emotion class labels ([class*=ListCard] / [class*=ListCardTitle]).