### PR TITLE
Add hCaptcha to the contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -43,6 +43,8 @@ nav_active: contact
                         <label class="block text-sm font-bold text-primary mb-2" for="message">{{ c.form.message_label }}</label>
                         <textarea class="w-full bg-surface-container-high border-none rounded-xl p-4 focus:ring-2 focus:ring-primary transition-all h-32" id="message" name="message" placeholder="{{ c.form.message_placeholder }}" required></textarea>
                     </div>
+                    <!-- hCaptcha (uses Web3Forms' free shared sitekey; swap for your own from web3forms.com dashboard if desired) -->
+                    <div class="h-captcha" data-sitekey="50b2fe65-b00b-4b9e-ad62-3ba471098be2"></div>
                     <button id="contact-submit" class="w-full py-4 organic-gradient text-on-primary rounded-xl font-bold text-lg hover:scale-[1.02] transition-transform editorial-shadow disabled:opacity-60 disabled:cursor-not-allowed" type="submit">
                         {{ c.form.submit_label }}
                     </button>
@@ -92,6 +94,7 @@ nav_active: contact
     </div>
 </main>
 
+<script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 <script>
 (function () {
     var form = document.getElementById("contact-form");
@@ -107,6 +110,13 @@ nav_active: contact
 
     form.addEventListener("submit", function (e) {
         e.preventDefault();
+
+        var captcha = form.querySelector('textarea[name="h-captcha-response"]');
+        if (!captcha || !captcha.value) {
+            showStatus("Please complete the captcha below before sending.", false);
+            return;
+        }
+
         button.disabled = true;
         var original = button.textContent;
         button.textContent = "Sending…";
@@ -131,6 +141,9 @@ nav_active: contact
             .finally(function () {
                 button.disabled = false;
                 button.textContent = original;
+                if (window.hcaptcha && typeof window.hcaptcha.reset === "function") {
+                    window.hcaptcha.reset();
+                }
             });
     });
 })();


### PR DESCRIPTION
Use Web3Forms' free shared hCaptcha sitekey (validated server-side by Web3Forms). Loads hCaptcha's own api.js so it stays isolated from our custom fetch submit; the h-captcha-response token rides along in FormData. Block submission until the captcha is solved and reset the widget after each send.