### PR TITLE
Add CMS toggle to show/hide individual pages

### DIFF
--- a/_data/about.yml
+++ b/_data/about.yml
@@ -1,3 +1,4 @@
+visible: true
 story:
   heading: Our Story
   paragraphs:

--- a/_data/brochure.yml
+++ b/_data/brochure.yml
@@ -1,3 +1,4 @@
+visible: true
 heading: Digital Brochure
 subheading: Download our latest catalog to see our full range of sustainable dinnerware.
 collection_title: DineStar 2024 Collection

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -1,3 +1,4 @@
+visible: true
 heading: Get in Touch
 subheading: Have questions about our products or services? We're here to help you transition to a more sustainable table.
 

--- a/_data/products.yml
+++ b/_data/products.yml
@@ -1,3 +1,4 @@
+visible: true
 heading: Our Collection
 intro: Explore our range of premium, sustainable palm leaf dinnerware designed for every occasion.
 items:

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,3 +1,4 @@
+visible: true
 heading: Our Services
 intro: Beyond products, we offer comprehensive solutions for businesses and events looking to make a sustainable impact.
 items:

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,10 +5,13 @@
         </a>
         <div class="hidden md:flex items-center gap-8">
             {% for item in site.data.navigation.items %}
+                {% assign page_data = site.data[item.slug] %}
+                {% if item.slug == 'home' or page_data.visible != false %}
                 {% if item.slug == page.nav_active %}
                     <a class="text-primary font-bold border-b-2 border-primary pb-1 text-sm tracking-wide" href="{{ item.url | relative_url }}">{{ item.title }}</a>
                 {% else %}
                     <a class="text-secondary hover:text-primary transition-colors text-sm tracking-wide" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                {% endif %}
                 {% endif %}
             {% endfor %}
         </div>
@@ -22,10 +25,13 @@
     <div id="mobile-menu" class="hidden md:hidden border-t border-outline-variant/10 bg-surface/95 glass-nav">
         <div class="flex flex-col px-6 py-4 gap-1">
             {% for item in site.data.navigation.items %}
+                {% assign page_data = site.data[item.slug] %}
+                {% if item.slug == 'home' or page_data.visible != false %}
                 {% if item.slug == page.nav_active %}
                     <a class="text-primary font-bold py-3 text-base tracking-wide" href="{{ item.url | relative_url }}">{{ item.title }}</a>
                 {% else %}
                     <a class="text-secondary hover:text-primary transition-colors py-3 text-base tracking-wide" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                {% endif %}
                 {% endif %}
             {% endfor %}
         </div>

--- a/_includes/page_unavailable.html
+++ b/_includes/page_unavailable.html
@@ -1,0 +1,8 @@
+<main class="pt-32 pb-24 min-h-[60vh] flex items-center">
+    <div class="max-w-2xl mx-auto px-6 text-center">
+        <span class="material-symbols-outlined text-primary text-6xl mb-4">visibility_off</span>
+        <h1 class="text-4xl font-extrabold text-primary mb-4 tracking-tight">Page unavailable</h1>
+        <p class="text-lg text-on-surface-variant mb-8">This page isn't available right now. Please check back later.</p>
+        <a href="{{ '/' | relative_url }}" class="inline-block px-8 py-4 organic-gradient text-on-primary rounded-3xl font-bold text-lg hover:scale-105 transition-transform editorial-shadow">Back to Home</a>
+    </div>
+</main>

--- a/about.html
+++ b/about.html
@@ -4,6 +4,7 @@ title: About Us | DineStar
 nav_active: about
 ---
 {% assign a = site.data.about %}
+{% if site.data.about.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-16 items-center mb-24">
@@ -40,3 +41,4 @@ nav_active: about
         </div>
     </div>
 </main>
+{% endif %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -119,6 +119,7 @@ collections:
         label: Products
         description: Page heading and the product cards. Add, remove, or reorder cards.
         fields:
+          - { label: Show this page on the site, name: visible, widget: boolean, default: true, hint: "Turn off to hide this page and remove it from the menu." }
           - { label: Page heading, name: heading, widget: string }
           - { label: Page intro text, name: intro, widget: text }
           - label: Products
@@ -136,6 +137,7 @@ collections:
         label: Services
         description: Page heading and the service items on the Our Services page.
         fields:
+          - { label: Show this page on the site, name: visible, widget: boolean, default: true, hint: "Turn off to hide this page and remove it from the menu." }
           - { label: Page heading, name: heading, widget: string }
           - { label: Page intro text, name: intro, widget: text }
           - label: Services
@@ -160,6 +162,7 @@ collections:
         label: About page
         description: Our Story and Our Core Values sections.
         fields:
+          - { label: Show this page on the site, name: visible, widget: boolean, default: true, hint: "Turn off to hide this page and remove it from the menu." }
           - label: Story section
             name: story
             widget: object
@@ -192,6 +195,7 @@ collections:
         label: Contact page
         description: Page heading, the enquiry form labels, contact info, and business hours.
         fields:
+          - { label: Show this page on the site, name: visible, widget: boolean, default: true, hint: "Turn off to hide this page and remove it from the menu." }
           - { label: Heading, name: heading, widget: string }
           - { label: Subheading, name: subheading, widget: text }
           - label: Enquiry form
@@ -238,6 +242,7 @@ collections:
         label: Brochure page
         description: Content on the Brochure download page.
         fields:
+          - { label: Show this page on the site, name: visible, widget: boolean, default: true, hint: "Turn off to hide this page and remove it from the menu." }
           - { label: Page heading, name: heading, widget: string }
           - { label: Page subheading, name: subheading, widget: text }
           - { label: Collection title, name: collection_title, widget: string }

--- a/brochure.html
+++ b/brochure.html
@@ -4,6 +4,7 @@ title: Brochure | DineStar
 nav_active: brochure
 ---
 {% assign b = site.data.brochure %}
+{% if site.data.brochure.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <header class="mb-16 text-center">
@@ -34,3 +35,4 @@ nav_active: brochure
         </div>
     </div>
 </main>
+{% endif %}

--- a/contact.html
+++ b/contact.html
@@ -4,6 +4,7 @@ title: Contact Us | DineStar
 nav_active: contact
 ---
 {% assign c = site.data.contact %}
+{% if site.data.contact.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <header class="mb-16 text-center">
@@ -93,6 +94,7 @@ nav_active: contact
         </div>
     </div>
 </main>
+{% endif %}
 
 <!-- recaptchacompat=off: register as native hCaptcha, not reCAPTCHA (Web3Forms free supports hCaptcha only) -->
 <script src="https://js.hcaptcha.com/1/api.js?recaptchacompat=off" async defer></script>

--- a/products.html
+++ b/products.html
@@ -3,6 +3,7 @@ layout: default
 title: Products | DineStar
 nav_active: products
 ---
+{% if site.data.products.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <header class="mb-16">
@@ -28,3 +29,4 @@ nav_active: products
         </div>
     </div>
 </main>
+{% endif %}

--- a/services.html
+++ b/services.html
@@ -3,6 +3,7 @@ layout: default
 title: Our Services | DineStar
 nav_active: services
 ---
+{% if site.data.services.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">
     <div class="max-w-7xl mx-auto px-6 md:px-12">
         <header class="mb-16 text-center">
@@ -34,3 +35,4 @@ nav_active: services
         </div>
     </div>
 </main>
+{% endif %}


### PR DESCRIPTION
New "Show this page on the site" boolean (default true) on Products, Services, About, Contact, and Brochure (Home is always visible). When a page is turned off it is:
  - removed from the desktop and mobile nav menus (nav.html filters by site.data[slug].visible)
  - replaced with a friendly "Page unavailable" notice if reached directly (new _includes/page_unavailable.html)