### PR TITLE
Configure custom domain dinestar.co.in

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dinestar.co.in

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Static marketing site for DineStar palm leaf dinnerware, built with Jekyll
 and edited via Decap CMS. Deployed on GitHub Pages.
 
-- Live site: https://ajithsinghsajitha.github.io/dinestar/
-- CMS: https://ajithsinghsajitha.github.io/dinestar/admin/
+- Live site: https://dinestar.co.in/
+- CMS: https://dinestar.co.in/admin/
 
 ## Repo layout
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: DineStar
 description: Sustainable Palm Leaf Dinnerware - Nature's Craft for Your Table.
-url: https://ajithsinghsajitha.github.io
-baseurl: /dinestar
+url: https://dinestar.co.in
+baseurl: ""
 # Default image used for social sharing (Open Graph / Twitter). 1200x630.
 share_image: /assets/images/og-default.jpg
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -10,9 +10,9 @@ publish_mode: editorial_workflow
 media_folder: assets/images/uploads
 public_folder: /assets/images/uploads
 
-site_url: https://ajithsinghsajitha.github.io/dinestar/
-display_url: https://ajithsinghsajitha.github.io/dinestar/
-logo_url: https://ajithsinghsajitha.github.io/dinestar/assets/images/ds-logo.svg
+site_url: https://dinestar.co.in/
+display_url: https://dinestar.co.in/
+logo_url: https://dinestar.co.in/assets/images/ds-logo.svg
 
 collections:
   - name: site_content

--- a/admin/index.html
+++ b/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex">
     <title>DineStar Content Manager</title>
-    <link rel="icon" type="image/svg+xml" href="https://ajithsinghsajitha.github.io/dinestar/assets/images/ds-logo.svg">
+    <link rel="icon" type="image/svg+xml" href="https://dinestar.co.in/assets/images/ds-logo.svg">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=block" rel="stylesheet">
     <style>
         :root {


### PR DESCRIPTION
- add CNAME for GitHub Pages custom domain
- _config.yml: url -> https://dinestar.co.in, baseurl -> "" (site now served at the domain root, not /dinestar/)
- point admin CMS site_url/display_url/logo_url and favicon at the new domain; update README links

Merge only after DNS + GitHub Pages custom domain are configured, since baseurl="" assumes the site is served at the apex.