### PR TITLE
Use clean URLs without .html extension

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,7 +15,7 @@ noindex: true
             <a href="{{ '/' | relative_url }}" class="px-8 py-4 organic-gradient text-on-primary rounded-3xl font-bold text-lg hover:scale-105 transition-transform editorial-shadow">
                 Back to Home
             </a>
-            <a href="{{ '/products.html' | relative_url }}" class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
+            <a href="{{ '/products/' | relative_url }}" class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
                 Browse Products
             </a>
         </div>

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -10,16 +10,16 @@ social:
 columns:
   - heading: Company
     links:
-      - { label: About Us, url: /about.html }
+      - { label: About Us, url: /about/ }
       - { label: Sustainability Report, url: "#" }
       - { label: Our Process, url: "#" }
       - { label: Terms of Service, url: "#" }
   - heading: Solutions
     links:
       - { label: Wholesale Inquiries, url: "#" }
-      - { label: Event Services, url: /services.html }
-      - { label: Brochure, url: /brochure.html }
-      - { label: Privacy Policy, url: /contact.html }
+      - { label: Event Services, url: /services/ }
+      - { label: Brochure, url: /brochure/ }
+      - { label: Privacy Policy, url: /contact/ }
 
 copyright_owner: DineStar Sustainable Solutions
 copyright_suffix: Crafted with 100% natural palm leaves.

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -12,7 +12,7 @@ curated_essentials:
   eyebrow: The Collection
   heading: Curated Essentials
   view_all_label: View All Products
-  view_all_url: /products.html
+  view_all_url: /products/
   featured:
     badge: Bestseller
     title: Dinnerware Sets

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,19 +1,19 @@
 items:
   - title: Home
-    url: /index.html
+    url: /
     slug: home
   - title: Products
-    url: /products.html
+    url: /products/
     slug: products
   - title: Our Services
-    url: /services.html
+    url: /services/
     slug: services
   - title: About Us
-    url: /about.html
+    url: /about/
     slug: about
   - title: Brochure
-    url: /brochure.html
+    url: /brochure/
     slug: brochure
   - title: Contact Us
-    url: /contact.html
+    url: /contact/
     slug: contact

--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@ layout: default
 title: About Us | DineStar
 description: Learn about DineStar — a purpose-driven maker of sustainable palm leaf dinnerware, harvesting naturally fallen Areca leaves with zero chemicals.
 nav_active: about
+permalink: /about/
 ---
 {% assign a = site.data.about %}
 {% if site.data.about.visible == false %}{% include page_unavailable.html %}{% else %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -30,7 +30,7 @@ collections:
             summary: "{{fields.title}}"
             fields:
               - { label: Label, name: title, widget: string }
-              - { label: URL, name: url, widget: string, hint: "e.g. /products.html" }
+              - { label: URL, name: url, widget: string, hint: "e.g. /products/" }
               - { label: Page slug (for active-link highlighting), name: slug, widget: string, required: false, hint: "Matches the page's nav_active; leave blank if unsure" }
 
       - file: _data/home.yml
@@ -58,7 +58,7 @@ collections:
               - { label: Eyebrow, name: eyebrow, widget: string }
               - { label: Heading, name: heading, widget: string }
               - { label: View-all link label, name: view_all_label, widget: string }
-              - { label: View-all link URL, name: view_all_url, widget: string, hint: "e.g. /products.html or # for none" }
+              - { label: View-all link URL, name: view_all_url, widget: string, hint: "e.g. /products/ or # for none" }
               - label: Featured card (large)
                 name: featured
                 widget: object

--- a/brochure.html
+++ b/brochure.html
@@ -3,6 +3,7 @@ layout: default
 title: Brochure | DineStar
 description: Download the DineStar catalog for full specifications, product list, and wholesale pricing of our sustainable palm leaf dinnerware.
 nav_active: brochure
+permalink: /brochure/
 ---
 {% assign b = site.data.brochure %}
 {% if site.data.brochure.visible == false %}{% include page_unavailable.html %}{% else %}

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@ layout: default
 title: Contact Us | DineStar
 description: Get in touch with DineStar for wholesale enquiries, bulk orders, and event supply of sustainable palm leaf dinnerware.
 nav_active: contact
+permalink: /contact/
 ---
 {% assign c = site.data.contact %}
 {% if site.data.contact.visible == false %}{% include page_unavailable.html %}{% else %}

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ nav_active: home
                 <a href="{{ curated.view_all_url | relative_url }}" class="px-8 py-4 organic-gradient text-on-primary rounded-3xl font-bold text-lg hover:scale-105 transition-transform editorial-shadow">
                     {{ hero.primary_button }}
                 </a>
-                <a href="{{ '/about.html' | relative_url }}" class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
+                <a href="{{ '/about/' | relative_url }}" class="px-8 py-4 bg-surface-container-lowest text-primary border border-outline-variant/20 rounded-3xl font-bold text-lg hover:bg-surface-container-low transition-colors">
                     {{ hero.secondary_button }}
                 </a>
             </div>
@@ -131,10 +131,10 @@ nav_active: home
                 {{ cta.description }}
             </p>
             <div class="flex flex-col sm:flex-row gap-4 relative z-10">
-                <a href="{{ '/products.html' | relative_url }}" class="px-10 py-4 bg-surface text-primary rounded-xl font-bold text-lg hover:bg-surface-bright transition-colors editorial-shadow">
+                <a href="{{ '/products/' | relative_url }}" class="px-10 py-4 bg-surface text-primary rounded-xl font-bold text-lg hover:bg-surface-bright transition-colors editorial-shadow">
                     {{ cta.primary_button }}
                 </a>
-                <a href="{{ '/contact.html' | relative_url }}" class="px-10 py-4 border-2 border-on-primary-container text-on-primary-container rounded-xl font-bold text-lg hover:bg-white/10 transition-colors">
+                <a href="{{ '/contact/' | relative_url }}" class="px-10 py-4 border-2 border-on-primary-container text-on-primary-container rounded-xl font-bold text-lg hover:bg-white/10 transition-colors">
                     {{ cta.secondary_button }}
                 </a>
             </div>

--- a/products.html
+++ b/products.html
@@ -3,6 +3,7 @@ layout: default
 title: Products | DineStar
 description: Browse DineStar's range of sustainable palm leaf dinnerware — round and square plates, bowls, containers, trays, and biodegradable wooden cutlery, available in bulk.
 nav_active: products
+permalink: /products/
 ---
 {% if site.data.products.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">

--- a/services.html
+++ b/services.html
@@ -3,6 +3,7 @@ layout: default
 title: Our Services | DineStar
 description: DineStar's services for businesses and events — bulk supply, wholesale, logistics and delivery support, and export of sustainable palm leaf dinnerware.
 nav_active: services
+permalink: /services/
 ---
 {% if site.data.services.visible == false %}{% include page_unavailable.html %}{% else %}
 <main class="pt-32 pb-24">


### PR DESCRIPTION
Add per-page permalinks (/products/, /services/, /about/, /brochure/, /contact/) so pages build to folders, and update every internal link (nav, footer, home CTAs, 404) and CMS hints to match. Home stays at /, 404 keeps its required /404.html.